### PR TITLE
create add and edit page. Multiple fixes

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,10 @@
 import { Routes } from '@angular/router';
+import { AddPage } from './features/habits/add-page/add-page';
+import { EditPage } from './features/habits/edit-page/edit-page';
 import { HabitsPage } from './features/habits/habits-page/habits-page';
 
-export const routes: Routes = [{ path: '', component: HabitsPage }];
+export const routes: Routes = [
+  { path: '', component: HabitsPage },
+  { path: 'add', component: AddPage },
+  { path: 'edit/:id', component: EditPage },
+];

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,10 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { App } from './app';
-import { MatSlideToggleModule } from '@angular/material/slide-toggle';
-import { MatIconRegistry } from '@angular/material/icon';
-import { RouterOutlet } from '@angular/router';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconRegistry } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { RouterOutlet } from '@angular/router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { App } from './app';
 
 describe('App Component', () => {
   let fixture: ComponentFixture<App>;

--- a/src/app/core/models/habit.model.ts
+++ b/src/app/core/models/habit.model.ts
@@ -1,10 +1,9 @@
 export interface Habit {
   id: string;
   name: string;
-  icon?: string;
+  icon: string;
   description?: string;
   createdAt: string; // ISO date
-  archived: boolean;
 }
 
-export type HabitInput = Omit<Habit, 'id' | 'createdAt' | 'archived'>;
+export type HabitInput = Omit<Habit, 'id' | 'createdAt'>;

--- a/src/app/core/services/habit-entry/habit-entry.service.spec.ts
+++ b/src/app/core/services/habit-entry/habit-entry.service.spec.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   HabitEntry,
   HabitEntryInput,

--- a/src/app/core/services/habit/habit.service.spec.ts
+++ b/src/app/core/services/habit/habit.service.spec.ts
@@ -1,5 +1,6 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { Habit, HabitInput } from '../../models';
 import { HabitEntryService } from '../habit-entry/habit-entry.service';
 import { HabitService } from './habit.service';
@@ -15,6 +16,7 @@ describe('HabitService', () => {
 
   const mockHabit: HabitInput = {
     name: 'Meditate',
+    icon: 'self_improvement',
     description: 'Daily meditation for mindfulness',
   };
 
@@ -51,6 +53,7 @@ describe('HabitService', () => {
     const mockHabit2 = {
       name: 'Exercise',
       description: 'Daily workout routine',
+      icon: 'fitness_center',
     };
 
     const insertedHabit1 = service.addHabit(mockHabit);
@@ -85,6 +88,7 @@ describe('HabitService', () => {
     const updatedHabit: HabitInput = {
       name: 'Meditate Updated',
       description: 'Updated meditation description',
+      icon: 'self_improvement',
     };
 
     service.updateHabit(updatedHabit, insertedHabit.id);
@@ -92,15 +96,6 @@ describe('HabitService', () => {
     const foundHabit = service.getHabitById(insertedHabit.id);
     expect(foundHabit?.name).toBe('Meditate Updated');
     expect(foundHabit?.description).toBe('Updated meditation description');
-  });
-
-  it('should toggle archive status of a habit', () => {
-    const insertedHabit = service.addHabit(mockHabit);
-
-    service.toggleArchive(insertedHabit.id);
-
-    const foundHabit = service.getHabitById(insertedHabit.id);
-    expect(foundHabit?.archived).toBeTruthy();
   });
 
   it('should create a habit entry when adding a habit', () => {
@@ -118,18 +113,15 @@ describe('HabitService', () => {
     const invalidHabit: HabitInput = {
       name: '',
       description: 'This should not be added',
+      icon: 'self_improvement',
     };
 
-    expect(() => service.addHabit(invalidHabit)).toThrowError(
-      'Habit name is required',
-    );
+    expect(() => service.addHabit(invalidHabit)).toThrowError('required');
   });
 
   it('should not allow adding two habits with the same name', () => {
     const insertedHabit = service.addHabit(mockHabit);
 
-    expect(() => service.addHabit(insertedHabit)).toThrowError(
-      'Two habits with the same name are not allowed',
-    );
+    expect(() => service.addHabit(insertedHabit)).toThrowError('duplicated');
   });
 });

--- a/src/app/core/services/habit/habit.service.ts
+++ b/src/app/core/services/habit/habit.service.ts
@@ -13,24 +13,23 @@ export class HabitService {
 
   getHabits = () => this.habits;
 
-  getHabitById(id: string) {
+  getHabitById(id: string): Habit | undefined {
     return this.habits().find((habit) => habit.id === id);
   }
 
   addHabit(habit: HabitInput): Habit {
     if (!habit.name) {
-      throw new Error('Habit name is required');
+      throw new Error('required');
     }
 
     if (this.habits().find((h) => h.name === habit.name)) {
-      throw new Error('Two habits with the same name are not allowed');
+      throw new Error('duplicated');
     }
 
     const newHabit: Habit = {
       id: uuid(),
       ...habit,
       createdAt: new Date().toISOString().slice(0, 10),
-      archived: false,
     };
     this.habits.update((h) => [...h, newHabit]);
 
@@ -47,17 +46,15 @@ export class HabitService {
   }
 
   updateHabit(updatedHabit: HabitInput, id: string) {
+    if (
+      this.habits().find((h) => h.name === updatedHabit.name && h.id !== id)
+    ) {
+      throw new Error('duplicated');
+    }
+
     this.habits.update((h) =>
       h.map((habit) =>
         habit.id === id ? { ...habit, ...updatedHabit } : habit,
-      ),
-    );
-  }
-
-  toggleArchive(id: string) {
-    this.habits.update((h) =>
-      h.map((habit) =>
-        habit.id === id ? { ...habit, archived: !habit.archived } : habit,
       ),
     );
   }

--- a/src/app/core/services/habit/habit.service.ts
+++ b/src/app/core/services/habit/habit.service.ts
@@ -22,7 +22,10 @@ export class HabitService {
       throw new Error('required');
     }
 
-    if (this.habits().find((h) => h.name === habit.name)) {
+    const normalizedName = habit.name.trim().toLowerCase();
+    if (
+      this.habits().find((h) => h.name.trim().toLowerCase() === normalizedName)
+    ) {
       throw new Error('duplicated');
     }
 
@@ -46,8 +49,11 @@ export class HabitService {
   }
 
   updateHabit(updatedHabit: HabitInput, id: string) {
+    const normalizedName = updatedHabit.name.trim().toLowerCase();
     if (
-      this.habits().find((h) => h.name === updatedHabit.name && h.id !== id)
+      this.habits().find(
+        (h) => h.name.trim().toLowerCase() === normalizedName && h.id !== id,
+      )
     ) {
       throw new Error('duplicated');
     }

--- a/src/app/core/services/habit/mock-habits.ts
+++ b/src/app/core/services/habit/mock-habits.ts
@@ -7,14 +7,12 @@ export const mockHabits: Habit[] = [
     icon: 'self_improvement',
     description: '10 minutes of mindfulness',
     createdAt: '2025-08-01',
-    archived: false,
   },
   {
     id: 'habit-2',
     name: 'Drink Water',
-    icon: 'local_drink',
+    icon: 'self_improvement',
     description: '8 glasses per day',
     createdAt: '2025-08-05',
-    archived: false,
   },
 ];

--- a/src/app/core/stores/habit-entry/habit-entry.store.spec.ts
+++ b/src/app/core/stores/habit-entry/habit-entry.store.spec.ts
@@ -1,7 +1,8 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { Habit, HabitEntry, HabitEntryInput } from '../../models';
-import { HabitEntryService, HabitService } from '../../services';
+import { HabitEntryService } from '../../services';
 import { mockHabitEntries } from '../../services/habit-entry/mock-habit-entries';
 import { HabitEntryStore } from './habit-entry.store';
 
@@ -11,8 +12,8 @@ describe('HabitEntryStore', () => {
   const habit: Habit = {
     id: 'habit-1',
     name: 'Test Habit',
+    icon: 'self_improvement',
     createdAt: new Date().toISOString().slice(0, 10),
-    archived: false,
   };
 
   beforeEach(() => {

--- a/src/app/features/habits/add-page/add-page.html
+++ b/src/app/features/habits/add-page/add-page.html
@@ -1,0 +1,34 @@
+<div class="flex flex-col h-screen">
+  <header class="flex items-center justify-end gap-6">
+    <h1 class="p-4 text-2xl font-bold">Add new habit</h1>
+
+    <button
+      data-testid="cancel-button"
+      class="flex flex-row items-center justify-center ml-5 mr-6"
+      routerLink="/"
+    >
+      Cancel
+    </button>
+  </header>
+  <main class="flex flex-col gap-4">
+    <h2 class="w-2/3 mx-auto font-bold text-center mt-4">
+      Give your new habit a name and a topic
+    </h2>
+
+    <app-habit-form
+      (submitHabit)="saveHabit($event)"
+      (formStatusChange)="isFormValid.set($event)"
+      class="flex flex-col w-full flex-auto"
+    ></app-habit-form>
+
+    <button
+      data-testid="save-button"
+      class="w-5/6 self-center"
+      matButton="outlined"
+      (click)="triggerSave()"
+      [disabled]="!isFormValid()"
+    >
+      Save
+    </button>
+  </main>
+</div>

--- a/src/app/features/habits/add-page/add-page.spec.ts
+++ b/src/app/features/habits/add-page/add-page.spec.ts
@@ -1,0 +1,74 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { HabitService } from '../../../core/services';
+import { AddPage } from './add-page';
+
+describe('AddPage', () => {
+  let component: AddPage;
+  let fixture: ComponentFixture<AddPage>;
+  let habitServiceMock: HabitService;
+
+  beforeEach(async () => {
+    habitServiceMock = {
+      getHabits: vi.fn().mockReturnValue([]),
+      addHabit: vi.fn(),
+      getHabitById: vi.fn(),
+    } as unknown as HabitService;
+
+    await TestBed.configureTestingModule({
+      imports: [AddPage],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        { provide: HabitService, useValue: habitServiceMock },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should navigate to the habits page on cancel', () => {
+    const cancelButton = fixture.nativeElement.querySelector(
+      '[data-testid="cancel-button"]',
+    );
+    cancelButton.click();
+
+    expect(cancelButton.getAttribute('routerLink')).toBe('/');
+  });
+
+  it('should have save button disabled when the form is invalid', () => {
+    const submitButton = fixture.nativeElement.querySelector(
+      '[data-testid="save-button"]',
+    );
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should trigger form submission when clicking the save button', () => {
+    component.habitFormComponent.habitForm.setValue({
+      name: 'Test Habit',
+      topic: 'Health',
+    });
+
+    const formSubmitSpy = vi.spyOn(component.habitFormComponent, 'onSubmit');
+    const submitButton = fixture.nativeElement.querySelector(
+      '[data-testid="save-button"]',
+    );
+    fixture.detectChanges();
+
+    submitButton.click();
+
+    expect(formSubmitSpy).toHaveBeenCalled();
+    expect(habitServiceMock.addHabit).toHaveBeenCalledWith({
+      name: 'Test Habit',
+      icon: 'Health',
+    });
+  });
+});

--- a/src/app/features/habits/add-page/add-page.ts
+++ b/src/app/features/habits/add-page/add-page.ts
@@ -1,0 +1,35 @@
+import { Component, inject, signal, ViewChild } from '@angular/core';
+import { MatButton } from '@angular/material/button';
+import { Router, RouterLink } from '@angular/router';
+import { HabitInput } from '../../../core/models';
+import { HabitService } from '../../../core/services';
+import { HabitForm } from '../../../shared/components/habit-form/habit-form';
+
+@Component({
+  selector: 'app-add-page',
+  imports: [RouterLink, MatButton, HabitForm],
+  templateUrl: './add-page.html',
+  styleUrl: './add-page.scss',
+})
+export class AddPage {
+  habitService = inject(HabitService);
+  router = inject(Router);
+  @ViewChild(HabitForm) habitFormComponent!: HabitForm;
+
+  isFormValid = signal<boolean>(false);
+
+  triggerSave() {
+    this.habitFormComponent.onSubmit();
+  }
+
+  saveHabit(habitInput: HabitInput) {
+    try {
+      this.habitService.addHabit(habitInput);
+      this.router.navigate(['/']);
+    } catch (error) {
+      if (error instanceof Error) {
+        this.habitFormComponent.setFieldError('name', error.message);
+      }
+    }
+  }
+}

--- a/src/app/features/habits/edit-page/edit-page.html
+++ b/src/app/features/habits/edit-page/edit-page.html
@@ -1,0 +1,45 @@
+<div class="flex flex-col h-screen">
+  <header class="flex items-center justify-end gap-6">
+    <h1 class="p-4 text-2xl font-bold">Edit habit</h1>
+
+    <button
+      data-testid="cancel-button"
+      class="flex flex-row items-center justify-center ml-5 mr-6"
+      routerLink="/"
+    >
+      Cancel
+    </button>
+  </header>
+  <main class="flex flex-col gap-4">
+    <h2 class="w-2/3 mx-auto font-bold text-center mt-4">
+      Update your habit's name and/or topic
+    </h2>
+
+    <app-habit-form
+      [habit]="habit()"
+      (submitHabit)="saveHabit($event)"
+      (formStatusChange)="isFormValid.set($event)"
+      class="flex flex-col items-start w-full flex-auto"
+    ></app-habit-form>
+
+    <button
+      data-testid="delete-button"
+      class="w-5/6 mx-auto"
+      [class.animate-shake]="highlightDelete"
+      color="warn"
+      matButton="tonal"
+      (click)="deleteHabit()"
+    >
+      {{ deleteStatus() }}
+    </button>
+    <button
+      data-testid="save-button"
+      class="w-5/6 mx-auto"
+      matButton="outlined"
+      (click)="triggerSave()"
+      [disabled]="!isFormValid()"
+    >
+      Save
+    </button>
+  </main>
+</div>

--- a/src/app/features/habits/edit-page/edit-page.scss
+++ b/src/app/features/habits/edit-page/edit-page.scss
@@ -1,0 +1,8 @@
+:host {
+  .mat-warn {
+    background: var(--mat-sys-error-container);
+    color: var(--mat-sys-on-error-container);
+    border: 1px solid var(--mat-sys-outline-variant);
+    font: var(--mat-sys-body-large);
+  }
+}

--- a/src/app/features/habits/edit-page/edit-page.spec.ts
+++ b/src/app/features/habits/edit-page/edit-page.spec.ts
@@ -1,0 +1,119 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ActivatedRoute,
+  convertToParamMap,
+  provideRouter,
+} from '@angular/router';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Habit } from '../../../core/models';
+import { HabitService } from '../../../core/services';
+import { EditPage } from './edit-page';
+
+describe('EditPage', () => {
+  let component: EditPage;
+  let fixture: ComponentFixture<EditPage>;
+  let habitServiceMock: HabitService;
+  const loadedHabit: Habit = {
+    id: '42',
+    name: 'Test Habit',
+    icon: 'Health',
+    createdAt: '2023-01-01',
+  };
+  const mockActivatedRoute = {
+    snapshot: {
+      paramMap: convertToParamMap({ id: '42' }),
+    },
+  };
+
+  beforeEach(async () => {
+    habitServiceMock = {
+      getHabits: vi.fn().mockReturnValue([]),
+      addHabit: vi.fn(),
+      getHabitById: vi.fn().mockReturnValue(loadedHabit),
+      updateHabit: vi.fn(),
+      removeHabit: vi.fn(),
+    } as unknown as HabitService;
+
+    await TestBed.configureTestingModule({
+      imports: [EditPage],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        { provide: HabitService, useValue: habitServiceMock },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EditPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should navigate to the habits page on cancel', () => {
+    const cancelButton = fixture.nativeElement.querySelector(
+      '[data-testid="cancel-button"]',
+    );
+    cancelButton.click();
+
+    expect(cancelButton.getAttribute('routerLink')).toBe('/');
+  });
+
+  it('should have save button disabled when the form is invalid', () => {
+    component.habitFormComponent.habitForm.setValue({
+      name: '',
+      topic: '',
+    });
+    fixture.detectChanges();
+
+    const submitButton = fixture.nativeElement.querySelector(
+      '[data-testid="save-button"]',
+    );
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('should load the habit data on init', () => {
+    component.ngOnInit();
+
+    expect(component.habit()).toEqual(loadedHabit);
+  });
+
+  it('should trigger form submission when clicking the save button', () => {
+    const formSubmitSpy = vi.spyOn(component.habitFormComponent, 'onSubmit');
+    const submitButton = fixture.nativeElement.querySelector(
+      '[data-testid="save-button"]',
+    );
+    fixture.detectChanges();
+
+    submitButton.click();
+
+    expect(formSubmitSpy).toHaveBeenCalled();
+    expect(habitServiceMock.updateHabit).toHaveBeenCalledWith(
+      {
+        name: 'Test Habit',
+        icon: 'Health',
+      },
+      '42',
+    );
+  });
+
+  it('should change delete button text on first click and delete on second click', () => {
+    const deleteButton = fixture.nativeElement.querySelector(
+      '[data-testid="delete-button"]',
+    );
+
+    deleteButton.click();
+    fixture.detectChanges();
+
+    expect(deleteButton.textContent).toContain('Are you sure?');
+
+    deleteButton.click();
+    fixture.detectChanges();
+
+    expect(habitServiceMock.removeHabit).toHaveBeenCalledWith('42');
+  });
+});

--- a/src/app/features/habits/edit-page/edit-page.ts
+++ b/src/app/features/habits/edit-page/edit-page.ts
@@ -1,0 +1,62 @@
+import { Component, inject, signal, ViewChild } from '@angular/core';
+import { MatButton } from '@angular/material/button';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Habit, HabitInput } from '../../../core/models';
+import { HabitService } from '../../../core/services';
+import { HabitForm } from '../../../shared/components';
+
+@Component({
+  selector: 'app-edit-page',
+  imports: [HabitForm, RouterLink, MatButton],
+  templateUrl: './edit-page.html',
+  styleUrl: './edit-page.scss',
+})
+export class EditPage {
+  route = inject(ActivatedRoute);
+  habitService = inject(HabitService);
+  router = inject(Router);
+
+  @ViewChild(HabitForm) habitFormComponent!: HabitForm;
+  id = this.route.snapshot.paramMap.get('id');
+  isFormValid = signal<boolean>(false);
+  habit = signal<Habit | undefined>(undefined);
+  deleteStatus = signal<'Delete' | 'Are you sure?'>('Delete');
+  highlightDelete = false;
+
+  ngOnInit() {
+    if (this.id) {
+      this.habit.set(this.habitService.getHabitById(this.id));
+    }
+  }
+
+  triggerSave() {
+    this.habitFormComponent.onSubmit();
+  }
+
+  deleteHabit() {
+    if (!this.id) {
+      return;
+    }
+
+    if (this.deleteStatus() === 'Are you sure?') {
+      this.habitService.removeHabit(this.id);
+      this.router.navigate(['/']);
+    } else {
+      this.deleteStatus.set('Are you sure?');
+      this.highlightDelete = true;
+    }
+  }
+
+  saveHabit(habitInput: HabitInput) {
+    if (this.id) {
+      try {
+        this.habitService.updateHabit(habitInput, this.id);
+        this.router.navigate(['/']);
+      } catch (error) {
+        if (error instanceof Error) {
+          this.habitFormComponent.setFieldError('name', error.message);
+        }
+      }
+    }
+  }
+}

--- a/src/app/features/habits/habits-page/habits-page.html
+++ b/src/app/features/habits/habits-page/habits-page.html
@@ -1,5 +1,5 @@
-<app-header />
-<main class="flex flex-col justify-center gap-4 p-4">
+<main class="h-screen flex flex-col gap-4 p-4">
+  <app-header />
   <p>Today - {{ currentDate | formatDate }}</p>
 
   @if (habits().length === 0) {
@@ -11,8 +11,8 @@
       <p class="text-sm">Rest is part of the process. See you tomorrow!</p>
     </article>
   } @else {
-    <article>
-      <mat-accordion>
+    <article class="max-h-3/4 overflow-y-scroll">
+      <mat-accordion [multi]="true">
         @for (habit of habits(); track habit.id) {
           <app-habit-card [habit]="habit" />
         }
@@ -22,9 +22,9 @@
 
   <button
     data-testid="new-habit-button"
-    class="w-1/2 m-auto"
+    class="w-1/2 self-center"
     matButton="outlined"
-    (click)="addHabit()"
+    routerLink="/add"
   >
     <mat-icon aria-hidden="false" aria-label="add">add_2</mat-icon>New habit
   </button>

--- a/src/app/features/habits/habits-page/habits-page.spec.ts
+++ b/src/app/features/habits/habits-page/habits-page.spec.ts
@@ -4,6 +4,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { HabitService } from '../../../core/services';
 import { mockHabits } from '../../../core/services/habit/mock-habits';
@@ -29,6 +30,7 @@ describe('HabitsPage', () => {
         { provide: DOCUMENT, useValue: globalThis.document },
         { provide: HabitService, useValue: habitServiceMock },
         provideZonelessChangeDetection(),
+        provideRouter([]),
       ],
     }).compileComponents();
 
@@ -97,16 +99,13 @@ describe('HabitsPage', () => {
     });
   });
 
-  it('should contain a button to add a new habit', () => {
+  it('should contain a button to add a new habit and redirect to add habit page', async () => {
     const addButton = fixture.debugElement.query(
       By.css('[data-testid="new-habit-button"]'),
     ).nativeElement;
 
     expect(addButton).toBeTruthy();
     expect(addButton.textContent).toContain('New habit');
-
-    addButton.click();
-    fixture.detectChanges();
-    expect(habitServiceMock.addHabit).toHaveBeenCalled();
+    expect(addButton.getAttribute('routerLink')).toBe('/add');
   });
 });

--- a/src/app/features/habits/habits-page/habits-page.ts
+++ b/src/app/features/habits/habits-page/habits-page.ts
@@ -2,6 +2,7 @@ import { Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
 import { HabitService } from '../../../core/services';
 import { HabitCard, Header } from '../../../shared/components';
 import { FormatDatePipe } from '../../../shared/pipes';
@@ -15,6 +16,7 @@ import { FormatDatePipe } from '../../../shared/pipes';
     Header,
     FormatDatePipe,
     HabitCard,
+    RouterLink,
   ],
   templateUrl: './habits-page.html',
   styleUrl: './habits-page.scss',
@@ -24,12 +26,4 @@ export class HabitsPage {
   habitService = inject(HabitService);
 
   habits = this.habitService.getHabits();
-
-  addHabit = () => {
-    this.habitService.addHabit({
-      name: 'Read every day',
-      icon: 'book',
-      description: 'Description of the new habit',
-    });
-  };
 }

--- a/src/app/shared/components/habit-card/habit-card.html
+++ b/src/app/shared/components/habit-card/habit-card.html
@@ -1,7 +1,7 @@
 <mat-expansion-panel class="w-full" hideToggle>
-  <mat-expansion-panel-header>
+  <mat-expansion-panel-header class="min-h-[4rem]">
     <div
-      class="left-1/2 flex items-center gap-1 w-full"
+      class="left-1/2 flex items-center w-full"
       matExpansionPanelToggleIndicator
     >
       @if (habit().icon) {
@@ -11,7 +11,7 @@
           }}</mat-icon>
         </p>
       }
-      <p class="text-lg">{{ habit().name }}</p>
+      <p class="p-4">{{ habit().name }}</p>
     </div>
 
     <div
@@ -45,15 +45,18 @@
       }
     </div>
   </mat-expansion-panel-header>
-  <aside>
+  <aside class="flex flex-col gap-2">
     <app-weekday-indicator [habitEntries]="habitEntries()" />
 
-    <section class="flex p-2">
+    <section class="flex">
       <div class="left-1/2 ml-2 flex flex-row items-center gap-1 w-full">
         <app-streak-display [habitEntries]="habitEntries()" />
       </div>
 
-      <div class="flex items-center right-1/2">
+      <div
+        class="flex items-center right-1/2"
+        routerLink="/edit/{{ habit().id }}"
+      >
         <p class="text-3xl">
           <mat-icon aria-hidden="false" aria-label="check"
             >edit_square</mat-icon

--- a/src/app/shared/components/habit-card/habit-card.scss
+++ b/src/app/shared/components/habit-card/habit-card.scss
@@ -1,0 +1,4 @@
+.mat-expansion-panel {
+  margin-bottom: 0.5rem;
+  margin-top: 0.5rem;
+}

--- a/src/app/shared/components/habit-card/habit-card.spec.ts
+++ b/src/app/shared/components/habit-card/habit-card.spec.ts
@@ -1,5 +1,7 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { Habit, HabitEntry } from '../../../core/models';
 import { HabitEntryService } from '../../../core/services';
 import { mockHabitEntries } from '../../../core/services/habit-entry/mock-habit-entries';
@@ -34,6 +36,10 @@ describe('HabitCard', () => {
       providers: [
         provideZonelessChangeDetection(),
         { provide: HabitEntryService, useValue: mockHabitEntryService },
+        {
+          provide: ActivatedRoute,
+          useValue: { snapshot: { paramMap: new Map([['id', 'habit-1']]) } },
+        },
       ],
     }).compileComponents();
 
@@ -46,7 +52,6 @@ describe('HabitCard', () => {
       icon: 'self_improvement',
       description: '10 minutes of mindfulness',
       createdAt: '2025-08-01',
-      archived: false,
     };
 
     fixture.componentRef.setInput('habit', habit);
@@ -88,7 +93,7 @@ describe('HabitCard', () => {
   });
 
   it('should print the habit name', () => {
-    const nameElement = fixture.nativeElement.querySelector('.text-lg');
+    const nameElement = fixture.nativeElement.querySelector('.p-4');
     expect(nameElement.textContent).toContain('Daily Meditation');
   });
 

--- a/src/app/shared/components/habit-card/habit-card.ts
+++ b/src/app/shared/components/habit-card/habit-card.ts
@@ -1,6 +1,7 @@
-import { Component, computed, inject, input } from '@angular/core';
+import { Component, inject, input } from '@angular/core';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIcon } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
 import { Habit } from '../../../core/models';
 import { HabitEntryStore } from '../../../core/stores/habit-entry/habit-entry.store';
 import { StreakDisplay } from '../../components/streak-display/streak-display';
@@ -8,7 +9,13 @@ import { WeekdayIndicator } from '../weekday-indicator/weekday-indicator';
 
 @Component({
   selector: 'app-habit-card',
-  imports: [MatIcon, MatExpansionModule, WeekdayIndicator, StreakDisplay],
+  imports: [
+    MatIcon,
+    MatExpansionModule,
+    WeekdayIndicator,
+    StreakDisplay,
+    RouterLink,
+  ],
   providers: [HabitEntryStore],
   templateUrl: './habit-card.html',
   styleUrl: './habit-card.scss',

--- a/src/app/shared/components/habit-form/habit-form.html
+++ b/src/app/shared/components/habit-form/habit-form.html
@@ -1,0 +1,65 @@
+<form
+  [formGroup]="habitForm"
+  (ngSubmit)="onSubmit()"
+  class="flex flex-col items-start w-full flex-auto m-0"
+>
+  <mat-form-field class="w-full p-4 mx-auto">
+    <mat-label>Habit name</mat-label>
+    <input
+      matInput
+      formControlName="name"
+      placeholder="e.g. Drink water"
+      maxlength="55"
+    />
+    @if (
+      habitForm.get("name")?.hasError("required") &&
+      habitForm.get("name")?.touched
+    ) {
+      <mat-error data-testid="required-name-error"
+        >Please enter a habit name</mat-error
+      >
+    }
+    @if (
+      habitForm.get("name")?.hasError("minlength") &&
+      habitForm.get("name")?.touched
+    ) {
+      <mat-error data-testid="minlength-name-error"
+        >Use at least 3 characters</mat-error
+      >
+    }
+    @if (
+      habitForm.get("name")?.hasError("duplicated") &&
+      habitForm.get("name")?.touched
+    ) {
+      <mat-error data-testid="duplicated-name-error"
+        >Duplicated names are not allowed</mat-error
+      >
+    }
+  </mat-form-field>
+
+  <mat-button-toggle-group
+    formControlName="topic"
+    class="flex flex-nowrap overflow-x-scroll w-11/12 mx-auto px-2 scroll-smooth"
+    (change)="onTopicChange($event)"
+  >
+    @for (topic of topics; track topic.name) {
+      <mat-button-toggle
+        #topicButton
+        class="flex items-center"
+        value="{{ topic.icon }}"
+      >
+        <mat-icon>{{ topic.icon }}</mat-icon>
+        <p class="text-sm">{{ topic.name }}</p>
+      </mat-button-toggle>
+    }
+  </mat-button-toggle-group>
+
+  @if (
+    habitForm.get("topic")?.hasError("required") &&
+    habitForm.get("topic")?.touched
+  ) {
+    <mat-error class="mx-auto" data-testid="required-topic-error"
+      >Please select a topic</mat-error
+    >
+  }
+</form>

--- a/src/app/shared/components/habit-form/habit-form.scss
+++ b/src/app/shared/components/habit-form/habit-form.scss
@@ -1,0 +1,3 @@
+.mat-button-toggle-group {
+  overflow-x: auto;
+}

--- a/src/app/shared/components/habit-form/habit-form.spec.ts
+++ b/src/app/shared/components/habit-form/habit-form.spec.ts
@@ -1,0 +1,126 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Habit } from '../../../core/models';
+import { HabitForm } from './habit-form';
+
+describe('HabitForm', () => {
+  let component: HabitForm;
+  let fixture: ComponentFixture<HabitForm>;
+  const habitInput: Habit = {
+    id: 'habit-1',
+    name: 'Daily Meditation',
+    icon: 'self_improvement',
+    description: '10 minutes of mindfulness',
+    createdAt: '2025-08-01',
+  };
+
+  beforeEach(async () => {
+    Element.prototype.scrollIntoView = vi.fn();
+
+    await TestBed.configureTestingModule({
+      imports: [HabitForm],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HabitForm);
+    component = fixture.componentInstance;
+
+    fixture.componentRef.setInput('habit', habitInput);
+    fixture.detectChanges();
+  });
+
+  it('should create the component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should present the name field and topic toggle', () => {
+    const nameField = fixture.nativeElement.querySelector(
+      'input[formControlName="name"]',
+    );
+    const topicToggle = fixture.nativeElement.querySelectorAll(
+      'mat-button-toggle[formControlName="topic"]',
+    );
+
+    expect(nameField).toBeTruthy();
+    expect(topicToggle).toBeTruthy();
+  });
+
+  it('should emit submitHabit event on form submission with capitalized name', () => {
+    const emitSpy = vi.spyOn(component.submitHabit, 'emit');
+
+    component.habitForm.setValue({
+      name: 'drink water',
+      topic: 'health_and_safety',
+    });
+
+    component.onSubmit();
+
+    expect(emitSpy).toHaveBeenCalledWith({
+      name: 'Drink water',
+      icon: 'health_and_safety',
+    });
+  });
+
+  it('should show validation errors for empty form', () => {
+    const nameControl = component.habitForm.get('name');
+    const topicControl = component.habitForm.get('topic');
+    component.habitForm.setValue({
+      name: '',
+      topic: '',
+    });
+
+    component.onSubmit();
+    fixture.detectChanges();
+
+    const requiredNameErrorElement = fixture.nativeElement.querySelector(
+      'mat-error[data-testid="required-name-error"]',
+    );
+    const requiredTopicErrorElement = fixture.nativeElement.querySelector(
+      'mat-error[data-testid="required-topic-error"]',
+    );
+    expect(component.habitForm.valid).toBeFalsy();
+    expect(nameControl?.hasError('required')).toBeTruthy();
+    expect(topicControl?.hasError('required')).toBeTruthy();
+    expect(requiredNameErrorElement).toBeTruthy();
+    expect(requiredTopicErrorElement).toBeTruthy();
+  });
+
+  it('should show validation error for name field shorter than 3 characters', () => {
+    const nameControl = component.habitForm.get('name');
+    component.habitForm.setValue({
+      name: 'ab',
+      topic: 'health_and_safety',
+    });
+
+    component.onSubmit();
+    fixture.detectChanges();
+
+    const minlengthNameErrorElement = fixture.nativeElement.querySelector(
+      'mat-error[data-testid="minlength-name-error"]',
+    );
+    expect(component.habitForm.valid).toBeFalsy();
+    expect(nameControl?.hasError('minlength')).toBeTruthy();
+    expect(minlengthNameErrorElement).toBeTruthy();
+  });
+
+  it('should show validation error for duplicated habit name', () => {
+    const nameControl = component.habitForm.get('name');
+    component.setFieldError('name', 'duplicated');
+
+    component.onSubmit();
+    fixture.detectChanges();
+
+    const duplicatedNameErrorElement = fixture.nativeElement.querySelector(
+      'mat-error[data-testid="duplicated-name-error"]',
+    );
+    expect(component.habitForm.valid).toBeFalsy();
+    expect(nameControl?.hasError('duplicated')).toBeTruthy();
+    expect(duplicatedNameErrorElement).toBeTruthy();
+  });
+
+  it('should be loaded with habit data', () => {
+    expect(component.habitForm.get('name')?.value).toBe(habitInput.name);
+    expect(component.habitForm.get('topic')?.value).toBe(habitInput.icon);
+  });
+});

--- a/src/app/shared/components/habit-form/habit-form.ts
+++ b/src/app/shared/components/habit-form/habit-form.ts
@@ -1,0 +1,131 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  inject,
+  Output,
+  QueryList,
+  ViewChildren,
+} from '@angular/core';
+import {
+  FormBuilder,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import {
+  MatButtonToggle,
+  MatButtonToggleChange,
+  MatButtonToggleModule,
+} from '@angular/material/button-toggle';
+import { MatFormField } from '@angular/material/form-field';
+import { MatIcon } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { Habit, HabitInput } from '../../../core/models';
+
+@Component({
+  selector: 'app-habit-form',
+  imports: [
+    MatFormField,
+    MatInputModule,
+    MatIcon,
+    MatButtonToggleModule,
+    ReactiveFormsModule,
+    FormsModule,
+  ],
+  templateUrl: './habit-form.html',
+  styleUrl: './habit-form.scss',
+})
+export class HabitForm {
+  @Input() habit?: Habit;
+  @Output() submitHabit = new EventEmitter<HabitInput>();
+  @Output() formStatusChange = new EventEmitter<boolean>();
+  @ViewChildren('topicButton') topicButtons!: QueryList<MatButtonToggle>;
+  fb = inject(FormBuilder);
+
+  habitForm = this.fb.group({
+    name: ['', [Validators.required, Validators.minLength(3)]],
+    topic: ['', Validators.required],
+  });
+
+  topics = [
+    { name: 'Home', icon: 'home' },
+    { name: 'Productivity', icon: 'work' },
+    { name: 'Relationships', icon: 'people' },
+    { name: 'Health', icon: 'health_and_safety' },
+    { name: 'Self-improvement', icon: 'self_improvement' },
+    { name: 'Finance', icon: 'savings' },
+    { name: 'Creativity', icon: 'brush' },
+    { name: 'Mindfulness', icon: 'spa' },
+    { name: 'Learning', icon: 'school' },
+    { name: 'Digital Wellbeing', icon: 'devices' },
+    { name: 'Community', icon: 'volunteer_activism' },
+    { name: 'Pets & Animals', icon: 'pets' },
+  ];
+
+  ngOnInit(): void {
+    this.habitForm.statusChanges.subscribe(() => {
+      this.formStatusChange.emit(this.habitForm.valid);
+    });
+
+    if (this.habit) {
+      this.habitForm.patchValue({
+        name: this.habit.name,
+        topic: this.habit.icon,
+      });
+    }
+  }
+
+  ngAfterViewInit() {
+    if (this.habit) {
+      this.scrollToSelectedIcon();
+    }
+  }
+
+  private scrollToSelectedIcon() {
+    setTimeout(() => {
+      const selected = this.topicButtons.find(
+        (btn) => btn.value === this.habitForm.value.topic,
+      );
+      selected?._buttonElement.nativeElement.scrollIntoView({
+        behavior: 'smooth',
+        inline: 'center',
+        block: 'nearest',
+      });
+    });
+  }
+
+  onTopicChange(event: MatButtonToggleChange) {
+    this.habitForm.patchValue({ topic: event.value });
+    this.scrollToSelectedIcon();
+  }
+
+  onSubmit(): void {
+    if (this.habitForm.invalid) {
+      this.habitForm.markAllAsTouched();
+      return;
+    }
+
+    const habitData = this.habitForm.value as { name: string; topic: string };
+    const habitEntry: HabitInput = {
+      name: this.capitalizeFirstLetter(habitData.name),
+      icon: habitData.topic,
+    };
+
+    this.submitHabit.emit(habitEntry);
+  }
+
+  setFieldError(field: string, errorKey: string, errorMessage?: string) {
+    const control = this.habitForm.get(field);
+    if (control) {
+      control.setErrors({
+        ...control.errors,
+        [errorKey]: errorMessage || true,
+      });
+    }
+  }
+
+  private capitalizeFirstLetter(string: string): string {
+    return [...string][0].toUpperCase() + [...string].slice(1).join('');
+  }
+}

--- a/src/app/shared/components/habit-form/habit-form.ts
+++ b/src/app/shared/components/habit-form/habit-form.ts
@@ -126,6 +126,6 @@ export class HabitForm {
   }
 
   private capitalizeFirstLetter(string: string): string {
-    return [...string][0].toUpperCase() + [...string].slice(1).join('');
+    return string.charAt(0).toUpperCase() + string.slice(1);
   }
 }

--- a/src/app/shared/components/header/header.html
+++ b/src/app/shared/components/header/header.html
@@ -1,9 +1,10 @@
-<header class="flex items-center justify-center gap-4">
-  <h1 class="p-4 text-3xl font-bold">Habit tracker</h1>
+<header class="flex items-center justify-center gap-2">
+  <h1 class="p-4 text-2xl font-bold">Habit tracker</h1>
 
   <article class="flex flex-row items-center justify-center gap-1">
     <mat-icon aria-hidden="false" aria-label="sunny">wb_sunny</mat-icon>
-    <mat-slide-toggle (toggleChange)="toggleTheme()"> </mat-slide-toggle>
+    <mat-slide-toggle hideIcon="true" (toggleChange)="toggleTheme()">
+    </mat-slide-toggle>
     <mat-icon aria-hidden="false" aria-label="moon">moon_stars</mat-icon>
   </article>
 </header>

--- a/src/app/shared/components/index.ts
+++ b/src/app/shared/components/index.ts
@@ -1,4 +1,5 @@
 export { HabitCard } from './habit-card/habit-card';
+export { HabitForm } from './habit-form/habit-form';
 export { Header } from './header/header';
 export { StreakDisplay } from './streak-display/streak-display';
 export { WeekdayIndicator } from './weekday-indicator/weekday-indicator';

--- a/src/app/shared/components/streak-display/streak-display.html
+++ b/src/app/shared/components/streak-display/streak-display.html
@@ -2,5 +2,5 @@
   <p class="text-3xl">
     <mat-icon aria-hidden="false" aria-label="streak">mode_heat</mat-icon>
   </p>
-  <p class="text-lg">Streak: {{ currentStreak() }}</p>
+  <p data-testid="streak-value">Streak: {{ currentStreak() }}</p>
 </div>

--- a/src/app/shared/components/streak-display/streak-display.spec.ts
+++ b/src/app/shared/components/streak-display/streak-display.spec.ts
@@ -1,10 +1,31 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { describe, expect, it } from 'vitest';
+import { HabitEntry } from '../../../core/models';
 import { StreakDisplay } from './streak-display';
 
 describe('StreakDisplay', () => {
   let component: StreakDisplay;
   let fixture: ComponentFixture<StreakDisplay>;
+  const today = new Date();
+  const yesterday = new Date(today);
+
+  yesterday.setDate(yesterday.getDate() - 1);
+
+  const testHabitEntries: HabitEntry[] = [
+    {
+      id: 'habit-2',
+      habitId: 'habit-1',
+      date: today.toISOString().slice(0, 10), // today
+      status: 'done',
+    },
+    {
+      id: 'habit-1',
+      habitId: 'habit-1',
+      date: yesterday.toISOString().slice(0, 10), // yesterday
+      status: 'done',
+    },
+  ];
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -14,10 +35,70 @@ describe('StreakDisplay', () => {
 
     fixture = TestBed.createComponent(StreakDisplay);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should calculate current streak correctly', () => {
+    fixture.componentRef.setInput('habitEntries', testHabitEntries);
+    fixture.detectChanges();
+
+    expect(component.currentStreak()).toBe(2);
+  });
+
+  it('should return 0 for empty habitEntries', () => {
+    fixture.componentRef.setInput('habitEntries', []);
+    fixture.detectChanges();
+
+    expect(component.currentStreak()).toBe(0);
+  });
+
+  it('should return 1 for non-consecutive streak', () => {
+    const entriesWithGap: HabitEntry[] = [
+      {
+        date: today.toISOString().slice(0, 10),
+        status: 'done',
+        id: '1',
+        habitId: 'h1',
+      },
+      {
+        date: new Date(today.getTime() - 2 * 86400000)
+          .toISOString()
+          .slice(0, 10),
+        status: 'done',
+        id: '2',
+        habitId: 'h1',
+      },
+    ];
+    fixture.componentRef.setInput('habitEntries', entriesWithGap);
+    fixture.detectChanges();
+
+    expect(component.currentStreak()).toBe(1);
+  });
+
+  it('should return 0 for entries not marked as done', () => {
+    const incompleteEntries: HabitEntry[] = [
+      {
+        date: today.toISOString().slice(0, 10),
+        status: 'missed',
+        id: '1',
+        habitId: 'h1',
+      },
+    ];
+    fixture.componentRef.setInput('habitEntries', incompleteEntries);
+    fixture.detectChanges();
+    expect(component.currentStreak()).toBe(0);
+  });
+
+  it('should render streak value in template', () => {
+    const streakText = fixture.nativeElement.querySelector(
+      '[data-testid="streak-value"]',
+    );
+    fixture.componentRef.setInput('habitEntries', testHabitEntries);
+    fixture.detectChanges();
+
+    expect(streakText.textContent).toContain('Streak: 2');
   });
 });

--- a/src/app/shared/components/streak-display/streak-display.ts
+++ b/src/app/shared/components/streak-display/streak-display.ts
@@ -23,8 +23,9 @@ export class StreakDisplay {
     const day = new Date();
 
     while (true) {
-      const iso = day.toISOString().slice(0, 10);
-      const entry = sorted.find((e) => e.date == iso);
+      const entry = sorted.find(
+        (e) => e.date == day.toISOString().slice(0, 10),
+      );
 
       if (entry?.status === 'done') {
         streak++;

--- a/src/app/shared/components/weekday-indicator/weekday-indicator.html
+++ b/src/app/shared/components/weekday-indicator/weekday-indicator.html
@@ -1,4 +1,4 @@
-<section class="flex items-center justify-center gap-2 p-2">
+<section class="flex items-center justify-center gap-2">
   @for (day of ["M", "T", "W", "Th", "F", "Sa", "Su"]; track day) {
     <p
       [ngClass]="{
@@ -6,7 +6,7 @@
         'bg-red-300 dark:bg-red-700': weekdayStatus()[day] === 'missed',
         'bg-slate-300 dark:bg-slate-700': weekdayStatus()[day] === 'pending',
       }"
-      class="w-9 h-9 flex items-center justify-center border-2 rounded-full text-lg font-semibold select-none"
+      class="w-8 h-8 flex items-center justify-center border-2 rounded-full font-semibold select-none"
     >
       {{ day }}
     </p>

--- a/src/app/shared/components/weekday-indicator/weekday-indicator.spec.ts
+++ b/src/app/shared/components/weekday-indicator/weekday-indicator.spec.ts
@@ -1,5 +1,6 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { WeekdayIndicator } from './weekday-indicator';
 
 describe('WeekdayIndicator', () => {
@@ -17,7 +18,7 @@ describe('WeekdayIndicator', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create the component', () => {
     expect(component).toBeTruthy();
   });
 });

--- a/src/app/shared/pipes/format-date/format-date-pipe.spec.ts
+++ b/src/app/shared/pipes/format-date/format-date-pipe.spec.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from 'vitest';
 import { FormatDatePipe } from './format-date-pipe';
 
 describe('FormatDatePipe', () => {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,22 +3,46 @@
 
 @custom-variant dark (&:where(.dark-mode, .dark-mode *));
 
+@theme {
+  --animate-shake: shake 0.6s ease;
+  @keyframes shake {
+    0%,
+    100% {
+      transform: translateX(0);
+    }
+    20%,
+    60% {
+      transform: translateX(-4px);
+    }
+    40%,
+    80% {
+      transform: translateX(4px);
+    }
+  }
+}
+
+$my-light-theme: mat.m2-define-light-theme(
+  (
+    color: (
+      primary: mat.$azure-palette,
+      accent: mat.$azure-palette,
+      theme-type: light,
+    ),
+    density: 0,
+  )
+);
+
 html {
   color-scheme: light;
 
-  @include mat.theme(
-    (
-      color: (
-        primary: mat.$azure-palette,
-        theme-type: light,
-      ),
-      density: 0,
-    )
-  );
+  @include mat.theme($my-light-theme);
+  @include mat.button-theme($my-light-theme);
 
   --mat-sys-surface: #d1d9f2;
   --mat-sys-surface-container-low: #d1d9f2;
   --mat-button-outlined-label-text-color: #333333;
+  --mat-form-field-filled-container-color: #d1d9f2;
+  --mat-menu-container-color: #e5ebfa;
 }
 
 html.dark-mode {
@@ -36,6 +60,13 @@ html.dark-mode {
   --mat-sys-surface: #1c2338;
   --mat-sys-surface-container-low: #1c2338;
   --mat-button-outlined-label-text-color: #e5ebfa;
+  --mat-button-outlined-outline-color: #e5ebfa;
+  --mat-form-field-filled-container-color: #1c2338;
+  --mat-menu-container-color: #333333;
+  --mat-button-toggle-background-color: #1c2338;
+  --mat-button-outlined-disabled-label-text-color: #e5ebfa8f;
+  --mat-button-outlined-disabled-outline-color: #e5ebfa8f;
+  --mat-sys-error-container: #93000a;
 }
 
 html,


### PR DESCRIPTION
This pull request introduces significant improvements to the habit management feature, including adding dedicated pages for creating and editing habits, refactoring the habit model and service, and updating related tests and routes. The changes streamline how habits are created, edited, and validated, and remove the archived status from the habit model for simplicity.

### Feature Additions

* Added `AddPage` and `EditPage` components for creating and editing habits, including their templates, styles, and routing configuration (`src/app/features/habits/add-page/add-page.ts`, `src/app/features/habits/add-page/add-page.html`, `src/app/features/habits/edit-page/edit-page.ts`, `src/app/features/habits/edit-page/edit-page.html`, `src/app/features/habits/edit-page/edit-page.scss`, `src/app/app.routes.ts`). [[1]](diffhunk://#diff-bdde05475417f0c01ffd7eb89fcd1d3b2d17cc17ae1f271f85a8a8d8dfb4b1e9R1-R35) [[2]](diffhunk://#diff-0a79ceac83909dec87bdf23424e726c471708e873336c994824c01d3bd2cd7b3R1-R34) [[3]](diffhunk://#diff-94b9ff9816e5769383ba40a81ea1e7a46bebd80db2fddabe89e75ed631df082bR1-R62) [[4]](diffhunk://#diff-cd4f9cc13432b3743df0911fe69fe24c0ee361a9b147eb7a4c21427659c208dbR1-R45) [[5]](diffhunk://#diff-2499b5162475af22df1d8867afd08261dfe175b6b7e408550042b96131a80362R1-R8) [[6]](diffhunk://#diff-7d01226345966b27520a30fae71d6f3d17f54d3d06bcbc3f0dff4195fc7d9cfcR2-R10)

### Habit Model and Service Refactor

* Removed the `archived` property from the `Habit` model and related logic in the service and mock data, and updated `HabitInput` type accordingly (`src/app/core/models/habit.model.ts`, `src/app/core/services/habit/habit.service.ts`, `src/app/core/services/habit/mock-habits.ts`). [[1]](diffhunk://#diff-e18daca41a7c3ef5a0171a06ec6a32cb1986837a5b3ccf4e01fd090194f6b46fL4-R9) [[2]](diffhunk://#diff-ecae35afafac3896706354ee0ce0fa4ca8c3fe6d73bc3c63d5c07e58c4a16c38L16-L33) [[3]](diffhunk://#diff-dfba6c22d0a0992cb540544835c4dd685898ca1d98f17f3bcc7a3e0432a67ffcL10-L18)
* Updated error handling in the habit service to use simpler error messages ('required', 'duplicated') and improved duplicate name validation for both creation and update (`src/app/core/services/habit/habit.service.ts`). [[1]](diffhunk://#diff-ecae35afafac3896706354ee0ce0fa4ca8c3fe6d73bc3c63d5c07e58c4a16c38L16-L33) [[2]](diffhunk://#diff-ecae35afafac3896706354ee0ce0fa4ca8c3fe6d73bc3c63d5c07e58c4a16c38L50-R57)

### Routing and UI Updates

* Added routes for the new add and edit habit pages in `app.routes.ts` and updated the main habits page layout (`src/app/app.routes.ts`, `src/app/features/habits/habits-page/habits-page.html`). [[1]](diffhunk://#diff-7d01226345966b27520a30fae71d6f3d17f54d3d06bcbc3f0dff4195fc7d9cfcR2-R10) [[2]](diffhunk://#diff-1a7359e0db3f2abab2ee9732b86b727c2cd7d429c2bef6d4e9500c35829440c2R1-L2)

### Test Updates and Additions

* Added comprehensive unit tests for the new `AddPage` and `EditPage` components, covering form validation, navigation, and service interactions (`src/app/features/habits/add-page/add-page.spec.ts`, `src/app/features/habits/edit-page/edit-page.spec.ts`). [[1]](diffhunk://#diff-8b7bd9524309dc8094aba4fc72e0e9d2b179c8afb0f83182fd8ed68096ade64fR1-R74) [[2]](diffhunk://#diff-99f6230dfc1ab6e93dea8be032e69326e54ee7ae1610ebabf76852f8e5d1f495R1-R119)
* Updated existing tests and test data to reflect the removal of the `archived` property and required `icon` field (`src/app/core/services/habit/habit.service.spec.ts`, `src/app/core/stores/habit-entry/habit-entry.store.spec.ts`). [[1]](diffhunk://#diff-2a39f5e82d9c5acb9fb3561d4fb871fc3fdcb0cd55132ba0f1ded3cbb4466c2dR3) [[2]](diffhunk://#diff-2a39f5e82d9c5acb9fb3561d4fb871fc3fdcb0cd55132ba0f1ded3cbb4466c2dR19) [[3]](diffhunk://#diff-2a39f5e82d9c5acb9fb3561d4fb871fc3fdcb0cd55132ba0f1ded3cbb4466c2dR56) [[4]](diffhunk://#diff-2a39f5e82d9c5acb9fb3561d4fb871fc3fdcb0cd55132ba0f1ded3cbb4466c2dR91) [[5]](diffhunk://#diff-2a39f5e82d9c5acb9fb3561d4fb871fc3fdcb0cd55132ba0f1ded3cbb4466c2dL97-L105) [[6]](diffhunk://#diff-2a39f5e82d9c5acb9fb3561d4fb871fc3fdcb0cd55132ba0f1ded3cbb4466c2dR116-R125) [[7]](diffhunk://#diff-75d6974a58e3ac12008772a950456e642433efb792baea5c8983f91c16d08958R3-R5) [[8]](diffhunk://#diff-75d6974a58e3ac12008772a950456e642433efb792baea5c8983f91c16d08958R15-L15)

### Test Setup Consistency

* Standardized test imports to use `vitest` for all test files for consistency (`src/app/app.spec.ts`, `src/app/core/services/habit-entry/habit-entry.service.spec.ts`, `src/app/core/services/habit/habit.service.spec.ts`, `src/app/core/stores/habit-entry/habit-entry.store.spec.ts`). [[1]](diffhunk://#diff-bee3d094bd6c620b532afb37b445f544ec2304de87a35b9d818bd50da4230e42L1-R7) [[2]](diffhunk://#diff-ac5ed1020fc20da87505c9225b3080ddc5e4499b9e40a5cde67b2719dfea8973R1) [[3]](diffhunk://#diff-2a39f5e82d9c5acb9fb3561d4fb871fc3fdcb0cd55132ba0f1ded3cbb4466c2dR3) [[4]](diffhunk://#diff-75d6974a58e3ac12008772a950456e642433efb792baea5c8983f91c16d08958R3-R5)